### PR TITLE
When fetching organization tokens from SignalFX use a session token i…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ## Bugfixes
 * veneur-prometheus now reports incremental counters instead of cumulative counters. This may cause dramatic differences in the statistics reported by veneur-prometheus.  Thanks, [kklipsch-stripe](https://github.com/kklipsch-stripe)!
+* fetch signalfx org tokens using a session token rather than using an org token.
 
 ## Bugfixes
 * Veneur listening on UDS for statsd metrics will respect the `read_buffer_size_bytes` config. Thanks, [prudhvi](https://github.com/prudhvi)!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@
 
 ## Bugfixes
 * veneur-prometheus now reports incremental counters instead of cumulative counters. This may cause dramatic differences in the statistics reported by veneur-prometheus.  Thanks, [kklipsch-stripe](https://github.com/kklipsch-stripe)!
-* fetch signalfx org tokens using a session token rather than using an org token.
+* fetch signalfx org tokens using a session token rather than using an org token. Thanks, [kamalh0](https://github.com/kamahl0)
+
 
 ## Bugfixes
 * Veneur listening on UDS for statsd metrics will respect the `read_buffer_size_bytes` config. Thanks, [prudhvi](https://github.com/prudhvi)!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ## Bugfixes
 * veneur-prometheus now reports incremental counters instead of cumulative counters. This may cause dramatic differences in the statistics reported by veneur-prometheus.  Thanks, [kklipsch-stripe](https://github.com/kklipsch-stripe)!
-* fetch signalfx org tokens using a session token rather than using an org token. Thanks, [kamalh0](https://github.com/kamahl0)
+* fetch signalfx org tokens using a session token rather than using an org token. Thanks, [csolidum](https://github.com/csolidum)
 
 
 ## Bugfixes

--- a/config.go
+++ b/config.go
@@ -65,12 +65,14 @@ type Config struct {
 	SignalfxAPIKey                            string    `yaml:"signalfx_api_key"`
 	SignalfxDynamicPerTagAPIKeysEnable        bool      `yaml:"signalfx_dynamic_per_tag_api_keys_enable"`
 	SignalfxDynamicPerTagAPIKeysRefreshPeriod string    `yaml:"signalfx_dynamic_per_tag_api_keys_refresh_period"`
+	SignalfxEmail                             string    `yaml:"signalfx_email"`
 	SignalfxEndpointAPI                       string    `yaml:"signalfx_endpoint_api"`
 	SignalfxEndpointBase                      string    `yaml:"signalfx_endpoint_base"`
 	SignalfxFlushMaxPerBody                   int       `yaml:"signalfx_flush_max_per_body"`
 	SignalfxHostnameTag                       string    `yaml:"signalfx_hostname_tag"`
 	SignalfxMetricNamePrefixDrops             []string  `yaml:"signalfx_metric_name_prefix_drops"`
 	SignalfxMetricTagPrefixDrops              []string  `yaml:"signalfx_metric_tag_prefix_drops"`
+	SignalfxPassword                          string    `yaml:"signalfx_password"`
 	SignalfxPerTagAPIKeys                     []struct {
 		APIKey string `yaml:"api_key"`
 		Name   string `yaml:"name"`

--- a/example.yaml
+++ b/example.yaml
@@ -350,6 +350,14 @@ signalfx_flush_max_per_body: 0
 # so it must be set for this to work properly.
 signalfx_dynamic_per_tag_api_keys_enable: false
 
+# Email for a SignalFx account. This is needed if signalfx_dynamic_per_tag_api_keys_enabed
+# is set to true, in order to create a session token for fetching org tokens.
+signalfx_email: ""
+
+# Password for SignalFx account. This is needed if signalfx_dynamic_per_tag_api_keys_enabled
+# is set to true, in order to create a session token for fetching org tokens.
+signalfx_password: ""
+
 # The period of the polling performed on SignalFX to fetch dynamic
 # tokens. This only matters if signalfx_dynamic_per_tag_api_keys_enable
 # is true. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".

--- a/example.yaml
+++ b/example.yaml
@@ -346,15 +346,17 @@ signalfx_flush_max_per_body: 0
 # list on name collision. The name of the key specified in SignalFX will
 # be used as the name. signalfx_api_key is the fallback key used to submit
 # metrics if signalfx_vary_key_by doesn't match any of the dynamic API
-# keys' names. signalfx_api_key is used to fetch the API keys from SignalFx,
-# so it must be set for this to work properly.
+# keys' names. signalfx_email and signalfx_password are used to create a
+# a session token, so those fields need to be set in order for this to
+# work properly. More information on session and org tokens can be found
+# [here](https://developers.signalfx.com/administration/access_tokens_overview.html#_org_token_security)
 signalfx_dynamic_per_tag_api_keys_enable: false
 
-# Email for a SignalFx account. This is needed if signalfx_dynamic_per_tag_api_keys_enabed
+# Email for a SignalFx account. This is needed if signalfx_dynamic_per_tag_api_keys_enable
 # is set to true, in order to create a session token for fetching org tokens.
 signalfx_email: ""
 
-# Password for SignalFx account. This is needed if signalfx_dynamic_per_tag_api_keys_enabled
+# Password for SignalFx account. This is needed if signalfx_dynamic_per_tag_api_keys_enable
 # is set to true, in order to create a session token for fetching org tokens.
 signalfx_password: ""
 

--- a/server.go
+++ b/server.go
@@ -488,7 +488,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 			return ret, err
 		}
 
-		sfxSink, err := signalfx.NewSignalFxSink(conf.SignalfxHostnameTag, conf.Hostname, ret.TagsAsMap, log, fallback, conf.SignalfxVaryKeyBy, byTagClients, conf.SignalfxMetricNamePrefixDrops, conf.SignalfxMetricTagPrefixDrops, metricSink, conf.SignalfxFlushMaxPerBody, conf.SignalfxAPIKey, conf.SignalfxDynamicPerTagAPIKeysEnable, dynamicKeyRefreshPeriod, conf.SignalfxEndpointBase, conf.SignalfxEndpointAPI, &tracedHTTP)
+		sfxSink, err := signalfx.NewSignalFxSink(conf.SignalfxHostnameTag, conf.Hostname, ret.TagsAsMap, log, fallback, conf.SignalfxVaryKeyBy, byTagClients, conf.SignalfxMetricNamePrefixDrops, conf.SignalfxMetricTagPrefixDrops, metricSink, conf.SignalfxFlushMaxPerBody, conf.SignalfxAPIKey, conf.SignalfxDynamicPerTagAPIKeysEnable, dynamicKeyRefreshPeriod, conf.SignalfxEndpointBase, conf.SignalfxEndpointAPI, conf.SignalfxEmail, conf.SignalfxPassword, &tracedHTTP)
 		if err != nil {
 			return ret, err
 		}

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -33,6 +33,8 @@ var eventURL *url.URL
 const (
 	datapointAddr string = "/v2/datapoint"
 	eventAddr     string = "/v2/event"
+	tokenAddr     string = "/v2/token"
+	sessionAddr   string = "/v2/session"
 )
 
 func init() {
@@ -157,6 +159,8 @@ type SignalFxSink struct {
 	maxPointsInBatch          int
 	metricsEndpoint           string
 	apiEndpoint               string
+	email                     string
+	password                  string
 	httpClient                *http.Client
 }
 
@@ -180,19 +184,24 @@ func NewClient(endpoint, apiKey string, client *http.Client) DPClient {
 }
 
 // NewSignalFxSink creates a new SignalFx sink for metrics.
-func NewSignalFxSink(hostnameTag string, hostname string, commonDimensions map[string]string, log *logrus.Logger, client DPClient, varyBy string, perTagClients map[string]DPClient, metricNamePrefixDrops []string, metricTagPrefixDrops []string, derivedMetrics samplers.DerivedMetricsProcessor, maxPointsInBatch int, defaultToken string, enableDynamicPerTagTokens bool, dynamicKeyRefreshPeriod time.Duration, metricsEndpoint string, apiEndpoint string, httpClient *http.Client) (*SignalFxSink, error) {
+func NewSignalFxSink(hostnameTag string, hostname string, commonDimensions map[string]string, log *logrus.Logger, client DPClient, varyBy string, perTagClients map[string]DPClient, metricNamePrefixDrops []string, metricTagPrefixDrops []string, derivedMetrics samplers.DerivedMetricsProcessor, maxPointsInBatch int, defaultToken string, enableDynamicPerTagTokens bool, dynamicKeyRefreshPeriod time.Duration, metricsEndpoint string, apiEndpoint string, email string, password string, httpClient *http.Client) (*SignalFxSink, error) {
 	var endpointStr string
 	if apiEndpoint != "" {
 		endpoint, err := url.Parse(apiEndpoint)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to parse signalfx api endpoint")
 		}
+		endpointStr = endpoint.String()
 
-		endpoint, err = endpoint.Parse("/v2/token")
+		// Check that the various api methods are valid url addresses
+		_, err = endpoint.Parse(tokenAddr)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to generate signalfx token endpoint")
 		}
-		endpointStr = endpoint.String()
+		_, err = endpoint.Parse(sessionAddr)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to generate signalfx session endpoint")
+		}
 	}
 
 	return &SignalFxSink{
@@ -213,6 +222,8 @@ func NewSignalFxSink(hostnameTag string, hostname string, commonDimensions map[s
 		maxPointsInBatch:          maxPointsInBatch,
 		metricsEndpoint:           metricsEndpoint,
 		apiEndpoint:               endpointStr,
+		email:                     email,
+		password:                  password,
 		httpClient:                httpClient,
 	}, nil
 }
@@ -250,7 +261,12 @@ func (sfx *SignalFxSink) clientByTagUpdater() {
 
 	ticker := time.NewTicker(sfx.dynamicKeyRefreshPeriod)
 	for range ticker.C {
-		tokens, err := fetchAPIKeys(sfx.httpClient, sfx.apiEndpoint, sfx.defaultToken)
+		sessionToken, err := getSessionToken(sfx.httpClient, sfx.apiEndpoint, sfx.email, sfx.password)
+		if err != nil {
+			sfx.log.WithError(err).Warn("Failed to create session token, Failed to fetch org tokens from SignalFX")
+			continue
+		}
+		tokens, err := fetchAPIKeys(sfx.httpClient, sfx.apiEndpoint, sessionToken)
 		if err != nil {
 			sfx.log.WithError(err).Warn("Failed to fetch new tokens from SignalFX")
 			continue
@@ -272,6 +288,41 @@ const (
 
 	limitQueryValue = 200
 )
+
+func getSessionToken(client *http.Client, endpoint, email, password string) (string, error) {
+	sessionEndpoint := endpoint + sessionAddr
+
+	jsonBody := []byte(fmt.Sprintf("{\"email\": \"%s\", \"password\": \"%s\"}", email, password))
+	resp, err := client.Post(sessionEndpoint, "application/json", bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return "", fmt.Errorf("invalid credentials when generating session token")
+	} else if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("signalfx api returned unknown response code when generating session: %s", resp.Status)
+	}
+
+	body := &bytes.Buffer{}
+	_, err = body.ReadFrom(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	var createSessionResponse = make(map[string]interface{})
+	err = json.Unmarshal(body.Bytes(), &createSessionResponse)
+	if err != nil {
+		return "", err
+	}
+
+	accessToken, ok := createSessionResponse["accessToken"].(string)
+	if !ok {
+		return "", fmt.Errorf("No access token returned when creating session")
+	}
+	return accessToken, nil
+}
 
 func getTokensApiResponseFromOffset(client *http.Client, endpoint, apiToken string, offset int) (*bytes.Buffer, error) {
 	b := &bytes.Buffer{}
@@ -315,13 +366,14 @@ func getTokensApiResponseFromOffset(client *http.Client, endpoint, apiToken stri
 }
 
 func fetchAPIKeys(client *http.Client, endpoint, apiToken string) (map[string]string, error) {
+	tokenEndpoint := endpoint + tokenAddr
+
 	allFetched := false
 	offset := 0
 
 	apiTokensByName := make(map[string]string)
-
 	for !allFetched {
-		body, err := getTokensApiResponseFromOffset(client, endpoint, apiToken, offset)
+		body, err := getTokensApiResponseFromOffset(client, tokenEndpoint, apiToken, offset)
 		if err != nil {
 			return nil, err
 		}

--- a/sinks/signalfx/signalfx.go
+++ b/sinks/signalfx/signalfx.go
@@ -204,6 +204,11 @@ func NewSignalFxSink(hostnameTag string, hostname string, commonDimensions map[s
 		}
 	}
 
+	// Check that email/pass is supplied if using dynampic per tag tokens
+	if enableDynamicPerTagTokens && (email == "" || password == "") {
+		return nil, errors.Wrap(err, "signalfx_email and signalfx_password need to be supplied if dynamic per tag tokens is enabled")
+	}
+
 	return &SignalFxSink{
 		defaultClient:             client,
 		clientsByTagValueMu:       &sync.RWMutex{},

--- a/sinks/signalfx/signalfx_test.go
+++ b/sinks/signalfx/signalfx_test.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -85,7 +84,7 @@ func TestNewSignalFxSink(t *testing.T) {
 	// test the variables that have been renamed
 	client := NewClient("http://www.example.com", "secret", http.DefaultClient)
 	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), client, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", nil)
+	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), client, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", "", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +109,7 @@ func TestNewSignalFxSink(t *testing.T) {
 func TestSignalFxFlushRouting(t *testing.T) {
 	fakeSink := NewFakeSink()
 	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", nil)
+	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", "", "", nil)
 
 	assert.NoError(t, err)
 
@@ -164,7 +163,7 @@ func TestSignalFxFlushRouting(t *testing.T) {
 func TestSignalFxFlushGauge(t *testing.T) {
 	fakeSink := NewFakeSink()
 	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", nil)
+	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", "", "", nil)
 
 	assert.NoError(t, err)
 
@@ -200,7 +199,7 @@ func TestSignalFxFlushGauge(t *testing.T) {
 func TestSignalFxFlushCounter(t *testing.T) {
 	fakeSink := NewFakeSink()
 	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", nil)
+	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", "", "", nil)
 	assert.NoError(t, err)
 
 	interMetrics := []samplers.InterMetric{samplers.InterMetric{
@@ -237,7 +236,7 @@ func TestSignalFxFlushCounter(t *testing.T) {
 func TestSignalFxFlushWithDrops(t *testing.T) {
 	fakeSink := NewFakeSink()
 	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, "", nil, []string{"foo.bar"}, []string{"baz:gorch"}, derived, 0, "", false, time.Second, "", "", nil)
+	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, "", nil, []string{"foo.bar"}, []string{"baz:gorch"}, derived, 0, "", false, time.Second, "", "", "", "", nil)
 	assert.NoError(t, err)
 
 	interMetrics := []samplers.InterMetric{
@@ -286,7 +285,7 @@ func TestSignalFxFlushWithDrops(t *testing.T) {
 func TestSignalFxFlushStatus(t *testing.T) {
 	fakeSink := NewFakeSink()
 	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", nil)
+	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", "", "", nil)
 	assert.NoError(t, err)
 
 	interMetrics := []samplers.InterMetric{samplers.InterMetric{
@@ -324,7 +323,7 @@ func TestSignalFxFlushStatus(t *testing.T) {
 func TestSignalFxServiceCheckFlushOther(t *testing.T) {
 	fakeSink := NewFakeSink()
 	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", nil)
+	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", "", "", nil)
 	assert.NoError(t, err)
 
 	serviceCheckMsg := "Service Farts starting[an example link](http://catchpoint.com/session_id \"Title\")"
@@ -345,7 +344,7 @@ func TestSignalFxServiceCheckFlushOther(t *testing.T) {
 func TestSignalFxEventFlush(t *testing.T) {
 	fakeSink := NewFakeSink()
 	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", nil)
+	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fakeSink, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", "", "", nil)
 	assert.NoError(t, err)
 
 	evMessage := "[an example link](http://catchpoint.com/session_id \"Title\")"
@@ -376,7 +375,7 @@ func TestSignalFxEventFlush(t *testing.T) {
 func TestSignalFxSetExcludeTags(t *testing.T) {
 	fakeSink := NewFakeSink()
 	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie", "boo": "snakes"}, logrus.New(), fakeSink, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", nil)
+	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie", "boo": "snakes"}, logrus.New(), fakeSink, "", nil, nil, nil, derived, 0, "", false, time.Second, "", "", "", "", nil)
 
 	sink.SetExcludedTags([]string{"foo", "boo", "host"})
 	assert.NoError(t, err)
@@ -440,7 +439,7 @@ func TestSignalFxFlushMultiKey(t *testing.T) {
 	specialized := NewFakeSink()
 
 	derived := newDerivedProcessor()
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fallback, "test_by", map[string]DPClient{"available": specialized}, nil, nil, derived, 0, "", false, time.Second, "", "", nil)
+	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fallback, "test_by", map[string]DPClient{"available": specialized}, nil, nil, derived, 0, "", false, time.Second, "", "", "", "", nil)
 
 	assert.NoError(t, err)
 
@@ -511,7 +510,7 @@ func TestSignalFxFlushBatches(t *testing.T) {
 
 	derived := newDerivedProcessor()
 	perBatch := 1
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fallback, "test_by", map[string]DPClient{}, nil, nil, derived, perBatch, "", false, time.Second, "", "", nil)
+	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fallback, "test_by", map[string]DPClient{}, nil, nil, derived, perBatch, "", false, time.Second, "", "", "", "", nil)
 
 	assert.NoError(t, err)
 
@@ -559,7 +558,7 @@ func TestSignalFxFlushBatchHang(t *testing.T) {
 
 	derived := newDerivedProcessor()
 	perBatch := 1
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fallback, "test_by", map[string]DPClient{}, nil, nil, derived, perBatch, "", false, time.Second, "", "", nil)
+	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fallback, "test_by", map[string]DPClient{}, nil, nil, derived, perBatch, "", false, time.Second, "", "", "", "", nil)
 
 	assert.NoError(t, err)
 
@@ -624,6 +623,9 @@ const (
     }
   ]
 }`
+	accessTokenResponse = `{ 
+		"accessToken": "SECRET_TOKEN" 
+}`
 )
 
 func TestSignalFxExtractTokensFromResponse(t *testing.T) {
@@ -661,23 +663,44 @@ func TestSignalFxExtractTokensFromResponse(t *testing.T) {
 
 // mockHandler cycles through a slice of predefined HTTP responses
 type mockHandler struct {
-	responses []string
-	index     int64
+	mutex     *sync.Mutex
+	responses map[string][]string
+	index     map[string]int64
 }
 
 func (m *mockHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	resp.WriteHeader(http.StatusOK)
-	response := m.responses[atomic.LoadInt64(&m.index)%int64(len(m.responses))]
+	path := req.URL.Path
+	responses := m.responses[path]
+
+	m.mutex.Lock()
+
+	if m.index == nil {
+		m.index = make(map[string]int64)
+	}
+	pathIndex, ok := m.index[path]
+	if !ok {
+		pathIndex = 0
+		m.index[path] = pathIndex
+	}
+	response := responses[pathIndex%int64(len(responses))]
+	m.index[path] = pathIndex + 1
+
+	m.mutex.Unlock()
+
 	resp.Write([]byte(response))
-	atomic.AddInt64(&m.index, 1)
 }
 
 func TestSignalFxFetchAPITokens(t *testing.T) {
 	m := &mockHandler{
-		responses: []string{
-			response1,
-			response3,
-			response2,
+		mutex: &sync.Mutex{},
+		responses: map[string][]string{
+			tokenAddr: []string{
+				response1,
+				response3,
+				response2,
+			},
+			sessionAddr: []string{accessTokenResponse},
 		},
 	}
 	expectedParams := []string{offsetQueryParam, limitQueryParam}
@@ -695,7 +718,7 @@ func TestSignalFxFetchAPITokens(t *testing.T) {
 			}
 		}
 
-		w.Write([]byte(m.responses[respCount]))
+		w.Write([]byte(m.responses[tokenAddr][respCount]))
 		respCount += 1
 	}))
 
@@ -713,10 +736,14 @@ func TestSignalFxFetchAPITokens(t *testing.T) {
 func TestSignalFxClientByTagUpdater(t *testing.T) {
 	const dynamicKeyRefreshPeriod = 1 * time.Millisecond
 	m := &mockHandler{
-		responses: []string{
-			response1,
-			response3,
-			response2,
+		mutex: &sync.Mutex{},
+		responses: map[string][]string{
+			tokenAddr: []string{
+				response1,
+				response3,
+				response2,
+			},
+			sessionAddr: []string{accessTokenResponse},
 		},
 	}
 
@@ -727,7 +754,7 @@ func TestSignalFxClientByTagUpdater(t *testing.T) {
 	derived := newDerivedProcessor()
 	perBatch := 1
 
-	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fallback, "test_by", map[string]DPClient{}, nil, nil, derived, perBatch, "", true, dynamicKeyRefreshPeriod, "", server.URL, server.Client())
+	sink, err := NewSignalFxSink("host", "glooblestoots", map[string]string{"yay": "pie"}, logrus.New(), fallback, "test_by", map[string]DPClient{}, nil, nil, derived, perBatch, "", true, dynamicKeyRefreshPeriod, "", server.URL, "", "", server.Client())
 	require.NoError(t, err)
 
 	err = sink.Start(nil)
@@ -744,7 +771,7 @@ LOOP:
 		case <-interval.C:
 			// The sink polls and updates serially, so by the time it has made the fourth
 			// request, it is guaranteed to have finished processing the third.
-			if atomic.LoadInt64(&m.index) >= 4 {
+			if m.index[tokenAddr] >= 4 {
 				break LOOP
 			}
 		}
@@ -761,7 +788,7 @@ LOOP:
 
 	actualPerTagClients := make([]string, 0)
 
-	mindex := atomic.LoadInt64(&m.index)
+	mindex := m.index[tokenAddr]
 	assert.True(t, mindex >= 3, "m.index should be at least 3, not %d", mindex)
 	assert.Equal(t, len(expectedPerTagClients), len(sink.clientsByTagValue), "Sink should have %d clients", len(expectedPerTagClients))
 	for tag, client := range sink.clientsByTagValue {
@@ -778,4 +805,39 @@ LOOP:
 	assert.Subset(t, expectedPerTagClients, actualPerTagClients, "The actual values should be a subset of the expected values")
 	assert.Subset(t, actualPerTagClients, expectedPerTagClients, "The expected values should be a subset of the actual values")
 
+}
+
+func TestCreateSessionToken(t *testing.T) {
+	user := "user"
+	password := "password"
+	m := &mockHandler{
+		mutex: &sync.Mutex{},
+		responses: map[string][]string{
+			sessionAddr: []string{accessTokenResponse},
+		},
+	}
+
+	server := httptest.NewServer(m)
+
+	token, err := getSessionToken(server.Client(), server.URL, user, password)
+	assert.NoError(t, err)
+	assert.Equal(t, token, "SECRET_TOKEN")
+}
+
+func TestCreateSessionTokenInvalidResponse(t *testing.T) {
+	user := "user"
+	password := "password"
+
+	m := &mockHandler{
+		mutex: &sync.Mutex{},
+		responses: map[string][]string{
+			sessionAddr: []string{"This is an invalid response"},
+		},
+	}
+	server := httptest.NewServer(m)
+
+	token, err := getSessionToken(server.Client(), server.URL, user, password)
+
+	assert.Error(t, err)
+	assert.Equal(t, token, "", "Token should by empty when there's an error creating the session")
 }


### PR DESCRIPTION
#### Summary
If signalfx_dynamic_per_tag_api_keys_enable is set to true, create a session token to fetch api keys using supplied email and password instead of using an org token.

#### Motivation
Last year SignalFx changed their api so that a session token is now required to fetch org tokens.

#### Test plan
Wrote unit tests for the signalfx sink testing fetching an org token before fetching dynamic org tokens.

#### Rollout/monitoring/revert plan
If you're using signalfx_dynamic_per_tag_api_keys_enable, also set signalfx_email and signalfx_password in your veneur config. You can check that this feature is working as inspected by checking that sf.org.numDatapointsReceivedByToken and sf.org.numCustomMetricsByToken to see if there is a reasonable amount of datapoints assigned to the tokens. Rolling back would involve setting signalfx_dynamic_per_tag_api_keys_enable